### PR TITLE
fix nutrients matching for April 2021 import

### DIFF
--- a/scripts/merge_sources.py
+++ b/scripts/merge_sources.py
@@ -50,7 +50,7 @@ def _convert_nutrient(nutrient):
         'id': int(nutrient.id),
         'name': nutrient.name,
         'unitName': _NEW_UNIT_NAMES.get(nutrient.unit_name, _UNKNOWN_UNIT),
-        'number': nutrient.nutrient_nbr,
+        'nutrient_nbr': nutrient.nutrient_nbr,
         'rank': int(nutrient.rank) if nutrient.rank else None
     })
 
@@ -125,7 +125,9 @@ def merge_sources(raw_data):
     # Convert nutrients to a dict for merging.
     # Skip nutrients with rank '' because it's not clear how to handle them.
     nutrients = {
-        nutrient.id: _convert_nutrient(nutrient)
+	# April 2021: food_nutrients.csv nutrient_id field contains in fact the nutrient_nbr field 
+
+        nutrient.nutrient_nbr: _convert_nutrient(nutrient)
         for nutrient in raw_data.nutrients}
 
     food_nutrients = defaultdict(list)


### PR DESCRIPTION
in April 2021, the food_nutrient.csv files contains in fact the "nutrient_nbr" in the "nutrient_id" field:

more food_nutrient.csv 
"id","fdc_id","nutrient_id","amount","data_points","derivation_id","min","max","median","footnote","min_y
ear_acquired"
"13706913","1105904","203","0","","71","","","","",""
"13706914","1105904","204","93.33","","71","","","","",""
"13706915","1105904","205","0","","75","","","","",""
"13706924","1105904","324","0","","75","","","","",""

nutrient_id starts at 1000, and here we have values like 200.

